### PR TITLE
Ensure commits get shortened to seven characters in displayed markdown

### DIFF
--- a/.changeset/rare-dots-mate.md
+++ b/.changeset/rare-dots-mate.md
@@ -1,0 +1,5 @@
+---
+'changesets-changelog-clean': patch
+---
+
+Ensure commits get shortened to seven characters in displayed markdown.

--- a/examples/example-changelog.md
+++ b/examples/example-changelog.md
@@ -2,8 +2,8 @@
 
 ### Patch Changes
 
-- Fix bug with `range` function returning incorrect range _[`#122`](this-is-just-an-example) [`28a1217`](this-is-just-an-example) [@exampleguy](this-is-just-an-example)_
-- Fix incorrect typings for `shuffle` function _[`#121`](this-is-just-an-example) [`0c783e7`](this-is-just-an-example) [@JustAnExample](this-is-just-an-example)_
+- Fix bug with `range` function returning incorrect range _[`#122`](this-is-just-an-example) [`28a1217`](https://github.com/example/repo/commit/28a12175b8f15ce269af4827cf263246094d8349) [@exampleguy](this-is-just-an-example)_
+- Fix incorrect typings for `shuffle` function _[`#121`](this-is-just-an-example) [`0c783e7`](https://github.com/example/repo/commit/0c783e744ee8776f010e693118af140d75340871) [@JustAnExample](this-is-just-an-example)_
 
 <details><summary>Updated 2 dependencies</summary>
 
@@ -23,24 +23,24 @@
 
 ### Minor Changes
 
-- Add new `keyBy` function for creating object maps _[`#120`](this-is-just-an-example) [`b15e41d`](this-is-just-an-example) [@somegal](this-is-just-an-example)_
+- Add new `keyBy` function for creating object maps _[`#120`](this-is-just-an-example) [`b15e41d`](https://github.com/example/repo/commit/b15e41ddf352520c1e1b35869371c7550b6bcacd) [@somegal](this-is-just-an-example)_
 
 ## 2.0.0
 
 ### Major Changes
 
-- **BREAKING CHANGE**: Drop support for Node 12 _[`#115`](this-is-just-an-example) [`e2ee02f`](this-is-just-an-example) [@anothaone](this-is-just-an-example)_
-- **BREAKING CHANGE**: Remove all deprecated functions _[`#114`](this-is-just-an-example) [`d15a2e5`](this-is-just-an-example) [@exampleguy](this-is-just-an-example)_
+- **BREAKING CHANGE**: Drop support for Node 12 _[`#115`](this-is-just-an-example) [`e2ee02f`](https://github.com/example/repo/commit/e2ee02f3d314e1a3e31545e5b7ed6fe00a91e805) [@anothaone](this-is-just-an-example)_
+- **BREAKING CHANGE**: Remove all deprecated functions _[`#114`](this-is-just-an-example) [`d15a2e5`](https://github.com/example/repo/commit/d15a2e5ad16398c057940806fecbb6c90119e7ab) [@exampleguy](this-is-just-an-example)_
 
 ### Minor Changes
 
-- Add new `pipe` function for composing functions _[`#116`](this-is-just-an-example) [`5136b58`](this-is-just-an-example) [@somegal](this-is-just-an-example)_
+- Add new `pipe` function for composing functions _[`#116`](this-is-just-an-example) [`5136b58`](https://github.com/example/repo/commit/5136b586190b63789005f4b13c6df52789c4cd9c) [@somegal](this-is-just-an-example)_
 
 ### Patch Changes
 
-- Improve typings for `groupBy` function _[`#119`](this-is-just-an-example) [`998b9a0`](this-is-just-an-example) [@anothaone](this-is-just-an-example)_
-- Fix bug with `flatten` function not flattening deeply nested arrays _[`#118`](this-is-just-an-example) [`751758e`](this-is-just-an-example) [@exampleguy](this-is-just-an-example)_
-- Fix bug with `chunk` function returning incorrect chunks _[`#117`](this-is-just-an-example) [`4bca3b1`](this-is-just-an-example) [@JustAnExample](this-is-just-an-example)_
+- Improve typings for `groupBy` function _[`#119`](this-is-just-an-example) [`998b9a0`](https://github.com/example/repo/commit/998b9a0ed612fccca95f978f8d4037a49a785577) [@anothaone](this-is-just-an-example)_
+- Fix bug with `flatten` function not flattening deeply nested arrays _[`#118`](this-is-just-an-example) [`751758e`](https://github.com/example/repo/commit/751758eb097a3ae953b300736bf58ff38ec26728) [@exampleguy](this-is-just-an-example)_
+- Fix bug with `chunk` function returning incorrect chunks _[`#117`](this-is-just-an-example) [`4bca3b1`](https://github.com/example/repo/commit/4bca3b12b704cc7b3dc7a0789e4b963646ddd49b) [@JustAnExample](this-is-just-an-example)_
 
 <details><summary>Updated 1 dependency</summary>
 
@@ -80,24 +80,24 @@
 
 ### Minor Changes
 
-- Add new `zip` function for zipping arrays _[`#113`](this-is-just-an-example) [`ebae477`](this-is-just-an-example) [@JustAnExample](this-is-just-an-example)_
+- Add new `zip` function for zipping arrays _[`#113`](this-is-just-an-example) [`ebae477`](https://github.com/example/repo/commit/ebae477fd558d7ca4c7eaca63a9c9a504b121084) [@JustAnExample](this-is-just-an-example)_
 
 ## 1.2.0
 
 ### Minor Changes
 
-- Add new `memoize` function for caching function results _[`#111`](this-is-just-an-example) [`c7a5fde`](this-is-just-an-example) [@anothaone](this-is-just-an-example)_
+- Add new `memoize` function for caching function results _[`#111`](this-is-just-an-example) [`c7a5fde`](https://github.com/example/repo/commit/c7a5fdecb1f90378a6c78c0804d0c0f9de83d367) [@anothaone](this-is-just-an-example)_
 
 ### Patch Changes
 
-- Improve performance of `flatMap` function _[`#112`](this-is-just-an-example) [`af2e201`](this-is-just-an-example) [@somegal](this-is-just-an-example)_
-- Fix bug with `uniq` function not removing duplicates _[`#110`](this-is-just-an-example) [`1d2a3c8`](this-is-just-an-example) [@exampleguy](this-is-just-an-example)_
+- Improve performance of `flatMap` function _[`#112`](this-is-just-an-example) [`af2e201`](https://github.com/example/repo/commit/af2e20143d68eff552c5b24bb01e911f43a8f3f7) [@somegal](this-is-just-an-example)_
+- Fix bug with `uniq` function not removing duplicates _[`#110`](this-is-just-an-example) [`1d2a3c8`](https://github.com/example/repo/commit/1d2a3c891dbcf97eda3ff230e890e339c72d9686) [@exampleguy](this-is-just-an-example)_
 
 ## 1.1.1
 
 ### Patch Changes
 
-- Fix incorrect typings for `pick` function _[`#109`](this-is-just-an-example) [`2aa8016`](this-is-just-an-example) [@JustAnExample](this-is-just-an-example)_
+- Fix incorrect typings for `pick` function _[`#109`](this-is-just-an-example) [`2aa8016`](https://github.com/example/repo/commit/2aa8016a1ae49fe79cde9be51ac51e576115db1f) [@JustAnExample](this-is-just-an-example)_
 
 <details><summary>Updated 2 dependencies</summary>
 
@@ -117,12 +117,12 @@
 
 ### Minor Changes
 
-- Add support for partial application of `compose` function _[`#107`](this-is-just-an-example) [`227b914`](this-is-just-an-example) [@anothaone](this-is-just-an-example)_
+- Add support for partial application of `compose` function _[`#107`](this-is-just-an-example) [`227b914`](https://github.com/example/repo/commit/227b91486218eee1d52de4b7bc8286b5dd18da03) [@anothaone](this-is-just-an-example)_
 
 ### Patch Changes
 
-- Improve typings for `reduce` function _[`#108`](this-is-just-an-example) [`6bc96f9`](this-is-just-an-example) [@somegal](this-is-just-an-example)_
-- Fix bug with `omit` function returning incorrect keys _[`#106`](this-is-just-an-example) [`cdbed3a`](this-is-just-an-example) [@exampleguy](this-is-just-an-example)_
+- Improve typings for `reduce` function _[`#108`](this-is-just-an-example) [`6bc96f9`](https://github.com/example/repo/commit/6bc96f923d399f4ab15280704a1d92e866c57657) [@somegal](this-is-just-an-example)_
+- Fix bug with `omit` function returning incorrect keys _[`#106`](this-is-just-an-example) [`cdbed3a`](https://github.com/example/repo/commit/cdbed3a915745f1ad336f322948fa30c4ea8d82f) [@exampleguy](this-is-just-an-example)_
 
 <details><summary>Updated 1 dependency</summary>
 
@@ -141,11 +141,11 @@
 
 ### Minor Changes
 
-- Add new `merge` function for merging objects _[`#105`](this-is-just-an-example) [`6b3c45f`](this-is-just-an-example) [@JustAnExample](this-is-just-an-example)_
+- Add new `merge` function for merging objects _[`#105`](this-is-just-an-example) [`6b3c45f`](https://github.com/example/repo/commit/6b3c45f2d43d16c028ef18e38cb1e516f653463d) [@JustAnExample](this-is-just-an-example)_
 
 ### Patch Changes
 
-- Fix `find` function returning wrong item _[`#104`](this-is-just-an-example) [`59395c0`](this-is-just-an-example) [@somegal](this-is-just-an-example)_
-- Improve performance of `filter` function _[`#103`](this-is-just-an-example) [`54563f9`](this-is-just-an-example) [@anothaone](this-is-just-an-example)_
-- Fix incorrect typing for `map` function _[`#102`](this-is-just-an-example) [`ec0b4f0`](this-is-just-an-example) [@exampleguy](this-is-just-an-example)_
-- Add support for TypeScript v5 _[`#101`](this-is-just-an-example) [`7fd0c60`](this-is-just-an-example) [@JustAnExample](this-is-just-an-example)_
+- Fix `find` function returning wrong item _[`#104`](this-is-just-an-example) [`59395c0`](https://github.com/example/repo/commit/59395c05c18b9c8904853715d4136921de0b48f1) [@somegal](this-is-just-an-example)_
+- Improve performance of `filter` function _[`#103`](this-is-just-an-example) [`54563f9`](https://github.com/example/repo/commit/54563f95fefa691baa82a522156322c21f7d6df3) [@anothaone](this-is-just-an-example)_
+- Fix incorrect typing for `map` function _[`#102`](this-is-just-an-example) [`ec0b4f0`](https://github.com/example/repo/commit/ec0b4f0b5c90ed0fa911a2972ccc452641b31563) [@exampleguy](this-is-just-an-example)_
+- Add support for TypeScript v5 _[`#101`](this-is-just-an-example) [`7fd0c60`](https://github.com/example/repo/commit/7fd0c60790602276b351d77e6ec25faa006ae9bf) [@JustAnExample](this-is-just-an-example)_

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "generate-example": "vitest example"
   },
   "dependencies": {
-    "@changesets/get-github-info": "^0.5.2",
-    "@changesets/types": "^5.2.1"
+    "@changesets/get-github-info": "^0.6.0",
+    "@changesets/types": "^6.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 dependencies:
   '@changesets/get-github-info':
-    specifier: ^0.5.2
-    version: 0.5.2
+    specifier: ^0.6.0
+    version: 0.6.0
   '@changesets/types':
-    specifier: ^5.2.1
-    version: 5.2.1
+    specifier: ^6.0.0
+    version: 6.0.0
 
 devDependencies:
   '@biomejs/biome':
@@ -260,8 +260,8 @@ packages:
       semver: 7.5.3
     dev: true
 
-  /@changesets/get-github-info@0.5.2:
-    resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
+  /@changesets/get-github-info@0.6.0:
+    resolution: {integrity: sha512-v/TSnFVXI8vzX9/w3DU2Ol+UlTZcu3m0kXTjTT4KlAdwSvwutcByYwyYn9hwerPWfPkT2JfpoX0KgvCEi8Q/SA==}
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.6.9
@@ -337,13 +337,8 @@ packages:
     resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
     dev: true
 
-  /@changesets/types@5.2.1:
-    resolution: {integrity: sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==}
-    dev: false
-
   /@changesets/types@6.0.0:
     resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
-    dev: true
 
   /@changesets/write@0.3.0:
     resolution: {integrity: sha512-slGLb21fxZVUYbyea+94uFiD6ntQW0M2hIKNznFizDhZPDgn2c/fv1UzzlW43RVzh1BEDuIqW6hzlJ1OflNmcw==}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,11 +41,11 @@ describe(getReleaseLine.name, () => {
     const result = await getReleaseLineAndMockGithub({
       repo: 'test/test',
       pull: 1500,
-      commit: 'c1f7a8d',
+      commit: 'c1f7a8dea1fbddde9382ead635716a8d2253a41b',
       user: 'tester',
     });
 
-    expect(result).toMatchInlineSnapshot('"- Added foo bar. _[`#1500`](https://test.test/pulls/1500) [`c1f7a8d`](https://test.test/commits/c1f7a8d) [tester](https://test.test/users/tester)_"');
+    expect(result).toMatchInlineSnapshot('"- Added foo bar. _[`#1500`](https://test.test/pulls/1500) [`c1f7a8d`](https://github.com/test/test/commit/c1f7a8dea1fbddde9382ead635716a8d2253a41b) [tester](https://test.test/users/tester)_"');
   });
 });
 
@@ -55,13 +55,13 @@ describe(getDependencyReleaseLine.name, () => {
       [
         {
           id: 'test-changeset-1',
-          commit: 'bde8a2c',
+          commit: 'bde8a2cea1fbddde9382ead635716a8d2253a41b',
           summary: 'Added foo bar.',
           releases: [{ name: 'pkg-a', type: 'patch' as const }],
         },
         {
           id: 'test-changeset-2',
-          commit: 'ab36ce7',
+          commit: 'ab36ce7ea1fbddde9382ead635716a8d2253a41b',
           summary: 'Changed another thing.',
           releases: [
             { name: 'pkg-a', type: 'patch' as const },
@@ -88,7 +88,7 @@ describe(getDependencyReleaseLine.name, () => {
 
       <small>
 
-      [\`bde8a2c\`](https://github.com/test/test/commit/bde8a2c) [\`ab36ce7\`](https://github.com/test/test/commit/ab36ce7)
+      [\`bde8a2c\`](https://github.com/test/test/commit/bde8a2cea1fbddde9382ead635716a8d2253a41b) [\`ab36ce7\`](https://github.com/test/test/commit/ab36ce7ea1fbddde9382ead635716a8d2253a41b)
 
       </small>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,14 +63,14 @@ const changelogFunctions: ChangelogFunctions = {
 
     try {
       const ghInfo = await getGithubInfo({ repo, commit });
-      links = ghInfo.links;
+      links = { ...ghInfo.links, commit: ghCommitMarkdownLink(repo, commit) };
     } catch (error) {
       if (throwOnGithubError) {
         throw error;
-      } else {
-        console.error('Failed to get Github info for commit', commit, error);
-        links = { commit: ghCommitMarkdownLink(repo, commit) };
       }
+
+      console.error('Failed to get Github info for commit', commit, error);
+      links = { commit: ghCommitMarkdownLink(repo, commit) };
     }
 
     const linksString = [monospaceLink(links.pull || ''), monospaceLink(links.commit || ''), links.user || ''].filter(Boolean).join(' ');


### PR DESCRIPTION
A change in the `get-github-info` dependency makes commits show with their full hash displayed. This PR shortens them all to 7 characters.
